### PR TITLE
avoid deprecation warning in sgd_separator

### DIFF
--- a/notebooks/fig_code/sgd_separator.py
+++ b/notebooks/fig_code/sgd_separator.py
@@ -22,7 +22,7 @@ def plot_sgd_separator():
     for (i, j), val in np.ndenumerate(X1):
         x1 = val
         x2 = X2[i, j]
-        p = clf.decision_function([x1, x2])
+        p = clf.decision_function(np.array([[x1, x2]]))
         Z[i, j] = p[0]
     levels = [-1.0, 0.0, 1.0]
     linestyles = ['dashed', 'solid', 'dashed']


### PR DESCRIPTION
Correction to avoid deprecation warning:
/home/user/anaconda3/envs/sklearn_pycon2015/lib/python3.5/site-packages/sklearn/utils/validation.py:386: DeprecationWarning: Passing 1d arrays as data is deprecated in 0.17 and willraise ValueError in 0.19. Reshape your data either using X.reshape(-1, 1) if your data has a single feature or X.reshape(1, -1) if it contains a single sample.
  DeprecationWarning)
